### PR TITLE
Update sim.py

### DIFF
--- a/sim.py
+++ b/sim.py
@@ -43,7 +43,7 @@ if __name__ == "__main__":
     c = int(sys.argv[3])
     lines = f.readlines()
     f.close()
-    alg = algm.alg(c, k=k)
+    alg = algm.alg(c)
     alg.setup(lines)
 
     time1 = time.time()


### PR DESCRIPTION
Line 46 would throw an error for ARC since that only takes one parameter i.e. the cache size. Removing k=k in this line will still work for other policies which take k as a default parameter.
